### PR TITLE
Fix build error

### DIFF
--- a/source/network/Packet.cpp
+++ b/source/network/Packet.cpp
@@ -1,5 +1,6 @@
 #include "RakLib/network/Packet.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstring>
 


### PR DESCRIPTION
Fixed an error that occurred while compiling in Visual Studio 2017.
('min' is not a member of 'std')